### PR TITLE
User&ShoppingCart connection and initial Usersession handling

### DIFF
--- a/src/main/java/bookstore/App.java
+++ b/src/main/java/bookstore/App.java
@@ -18,7 +18,8 @@ public class App
     }
 
     @Bean
-    public CommandLineRunner demoInventory(InventoryRepository inventoryRepository, BookRepository bookRepo, AuthorRepository authorRepo, InventoryItemRepository itemRepository) {
+    public CommandLineRunner demoInventory(InventoryRepository inventoryRepository, BookRepository bookRepo, AuthorRepository authorRepo, InventoryItemRepository itemRepository,
+                                           UserRepository userRepository, ShoppingCartRepository shoppingCartRepository) {
         return (args) -> {
             Book book1;
             Book book2;
@@ -55,22 +56,29 @@ public class App
             inventory.addItemToInventory(item2);
 
             inventoryRepository.save(inventory);
-        };
-    }
-    /**
-     * Setup sample users
-     * @author Thanuja Sivaananthan
-     *
-     * @param repository    user repository
-     * @return              CommandLineRunner object
-     */
-    @Bean
-    public CommandLineRunner demoUsers(UserRepository repository) {
-        return (args) -> {
+
             // save a few users and owners
-            repository.save(new BookOwner("AdminOwner", "Password123"));
-            repository.save(new BookUser("User1", "Password45"));
-            repository.save(new BookUser("User2", "Password67"));
+            BookOwner bookOwner = new BookOwner("AdminOwner", "Password123");
+            BookUser bookUser1 = new BookUser("User1", "Password45");
+            BookUser bookUser2 = new BookUser("User2", "Password67");
+
+            ShoppingCart shoppingCart1 = new ShoppingCart(inventory);
+            ShoppingCart shoppingCart2 = new ShoppingCart(inventory);
+            ShoppingCart shoppingCart3 = new ShoppingCart(inventory);
+
+            // need to save shoppingCarts first, then set shoppingCart for the user, then save the user
+            shoppingCartRepository.save(shoppingCart1);
+            shoppingCartRepository.save(shoppingCart2);
+            shoppingCartRepository.save(shoppingCart3);
+
+            bookOwner.setShoppingCart(shoppingCart1);
+            bookUser1.setShoppingCart(shoppingCart2);
+            bookUser2.setShoppingCart(shoppingCart3);
+
+            userRepository.save(bookOwner);
+            userRepository.save(bookUser1);
+            userRepository.save(bookUser2);
+
         };
     }
 }

--- a/src/main/java/bookstore/inventory/CheckoutController.java
+++ b/src/main/java/bookstore/inventory/CheckoutController.java
@@ -21,7 +21,6 @@ public class CheckoutController {
     private final ShoppingCartRepository shoppingCartRepository;
     private final ShoppingCartItemRepository shoppingCartItemRepository;
     private final InventoryItemRepository inventoryItemRepository;
-    private final UserRepository loggedInUserRepository;
     private UserController userController;
     private boolean checkoutFlag = false;
 
@@ -31,12 +30,11 @@ public class CheckoutController {
      * @param authorRepo repository of authors
      * @param bookRepo   repository of books
      */
-    public CheckoutController(AuthorRepository authorRepo, BookRepository bookRepo, InventoryRepository inventoryRepo, InventoryItemRepository inventoryItemRepo, ShoppingCartRepository shoppingCartRepository, ShoppingCartItemRepository shoppingCartItemRepository, UserRepository loggedInUserRepository, UserController userController) {
+    public CheckoutController(AuthorRepository authorRepo, BookRepository bookRepo, InventoryRepository inventoryRepo, InventoryItemRepository inventoryItemRepo, ShoppingCartRepository shoppingCartRepository, ShoppingCartItemRepository shoppingCartItemRepository, UserController userController) {
         this.authorRepository = authorRepo;
         this.bookRepository = bookRepo;
         this.inventoryRepository = inventoryRepo;
         this.inventoryItemRepository = inventoryItemRepo;
-        this.loggedInUserRepository = loggedInUserRepository;
         this.shoppingCartRepository = shoppingCartRepository;
         this.shoppingCartItemRepository = shoppingCartItemRepository;
         this.userController = userController;
@@ -55,11 +53,7 @@ public class CheckoutController {
     (@RequestParam(name = "searchValue", required = false, defaultValue = "") String searchValue, Model model) {
        checkoutFlag = false;
         if(this.userController.getUserAccess()){
-            List<BookUser> loggedInUsers = (List<BookUser>) loggedInUserRepository.findAll();
-            BookUser loggedInUser = null;
-            if (!loggedInUsers.isEmpty()) {
-                loggedInUser = loggedInUsers.get(0);
-            }
+            BookUser loggedInUser = userController.getLoggedInUser();
 
             Inventory inventory = inventoryRepository.findById(1); // assuming one inventory
 
@@ -125,13 +119,8 @@ public class CheckoutController {
         
         System.out.println("going into add to cart");
         System.out.println("SELECTED ITEM: " + Arrays.toString(selectedItems));
-        List<BookUser> loggedInUsers = (List<BookUser>) loggedInUserRepository.findAll();
-        BookUser loggedInUser = null;
-        if (!loggedInUsers.isEmpty()) {
-            loggedInUser = loggedInUsers.get(0);
-        }
+        BookUser loggedInUser = userController.getLoggedInUser();
 
-        //TODO - if user does not already have a shopping cart
         ShoppingCart shoppingCart = getOrCreateShoppingCart();
 
         if (selectedItems != null) {
@@ -210,11 +199,7 @@ public class CheckoutController {
         System.out.println("going into remove from cart");
         System.out.println("SELECTED ITEM: " + Arrays.toString(selectedItems));
 
-        List<BookUser> loggedInUsers = (List<BookUser>) loggedInUserRepository.findAll();
-        BookUser loggedInUser = null;
-        if (!loggedInUsers.isEmpty()) {
-            loggedInUser = loggedInUsers.get(0);
-        }
+        BookUser loggedInUser = userController.getLoggedInUser();
 
         //TODO - if user does not already have a shopping cart
         ShoppingCart shoppingCart = getOrCreateShoppingCart();
@@ -281,9 +266,17 @@ public class CheckoutController {
     /**
      * Method to retrieve shopping cart for user
      * @return the shopping cart
+     * @author Maisha Abdullah
+     * @author Thanuja Sivaananthan
      */
     private ShoppingCart getOrCreateShoppingCart(){
-        return shoppingCartRepository.findById(1) != null ? shoppingCartRepository.findById(1) : new ShoppingCart(inventoryRepository.findById(1));
+        BookUser bookUser = userController.getLoggedInUser();
+        if (bookUser != null){
+            return bookUser.getShoppingCart();
+        } else {
+            return new ShoppingCart(inventoryRepository.findById(1));
+        }
+//        return shoppingCartRepository.findById(1) != null ? shoppingCartRepository.findById(1) : new ShoppingCart(inventoryRepository.findById(1));
     }
 
     /** 

--- a/src/main/java/bookstore/inventory/CheckoutController.java
+++ b/src/main/java/bookstore/inventory/CheckoutController.java
@@ -271,9 +271,10 @@ public class CheckoutController {
      */
     private ShoppingCart getOrCreateShoppingCart(){
         BookUser bookUser = userController.getLoggedInUser();
-        if (bookUser != null){
+        if (bookUser != null && bookUser.getShoppingCart() != null){
             return bookUser.getShoppingCart();
         } else {
+            System.out.println("ERROR, USER OR SHOPPINGCART IS NULL");
             return new ShoppingCart(inventoryRepository.findById(1));
         }
 //        return shoppingCartRepository.findById(1) != null ? shoppingCartRepository.findById(1) : new ShoppingCart(inventoryRepository.findById(1));

--- a/src/main/java/bookstore/inventory/CheckoutController.java
+++ b/src/main/java/bookstore/inventory/CheckoutController.java
@@ -83,6 +83,10 @@ public class CheckoutController {
      */
     @GetMapping("/viewBook")
     public String viewBook(@RequestParam(name = "isbn") String isbn, Model model) { //TODO pass in isbn when calling this endpoint
+        if(!this.userController.getUserAccess()){
+            return "access-denied";
+        }
+
         Book bookToDisplay = bookRepository.findByIsbn(isbn);
         model.addAttribute("book", bookToDisplay);
         return "book-info";

--- a/src/main/java/bookstore/inventory/CheckoutController.java
+++ b/src/main/java/bookstore/inventory/CheckoutController.java
@@ -273,11 +273,10 @@ public class CheckoutController {
         BookUser bookUser = userController.getLoggedInUser();
         if (bookUser != null && bookUser.getShoppingCart() != null){
             return bookUser.getShoppingCart();
-        } else {
+        } else { // This shouldn't happen
             System.out.println("ERROR, USER OR SHOPPINGCART IS NULL");
             return new ShoppingCart(inventoryRepository.findById(1));
         }
-//        return shoppingCartRepository.findById(1) != null ? shoppingCartRepository.findById(1) : new ShoppingCart(inventoryRepository.findById(1));
     }
 
     /** 

--- a/src/main/java/bookstore/inventory/CheckoutController.java
+++ b/src/main/java/bookstore/inventory/CheckoutController.java
@@ -102,6 +102,11 @@ public class CheckoutController {
      */
     @GetMapping("/addToCart")
     public String addToCartForm(Model model) {
+
+        if(!this.userController.getUserAccess()){
+            return "access-denied";
+        }
+
         model.addAttribute("inventory", inventoryItemRepository.findAll());
         //model.addAttribute("user", loggedInUser);
         return "home";
@@ -183,6 +188,10 @@ public class CheckoutController {
      */
     @GetMapping("/removeFromCart")
     public String removeFromCartForm (Model model){
+        if(!this.userController.getUserAccess()){
+            return "access-denied";
+        }
+
         model.addAttribute("inventory", inventoryItemRepository.findAll());
         return "home";
     }
@@ -285,6 +294,11 @@ public class CheckoutController {
     */
     @GetMapping("/checkout")
     public String viewCart(Model model) {
+
+        if(!this.userController.getUserAccess()){
+            return "access-denied";
+        }
+
         checkoutFlag = true;
         ShoppingCart shoppingCart = getOrCreateShoppingCart();
 
@@ -299,11 +313,7 @@ public class CheckoutController {
         model.addAttribute("items", shoppingCart.getBooksInCart());
         model.addAttribute("totalPrice", roundedPrice);
 
-        if (this.userController.getUserAccess()) {
-            return "checkout";
-        } else {
-            return "access-denied";
-        }
+        return "checkout";
    }
 
 

--- a/src/main/java/bookstore/inventory/ShoppingCart.java
+++ b/src/main/java/bookstore/inventory/ShoppingCart.java
@@ -15,7 +15,7 @@ import java.util.List;
 @Entity
 public class ShoppingCart {
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private BookUser user;
 
     @Id

--- a/src/main/java/bookstore/inventory/ShoppingCart.java
+++ b/src/main/java/bookstore/inventory/ShoppingCart.java
@@ -15,16 +15,14 @@ import java.util.List;
 @Entity
 public class ShoppingCart {
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    private BookUser user;
-
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue (strategy = GenerationType.IDENTITY)
     private Long id;
 
     @OneToMany(mappedBy = "shoppingCart", cascade = CascadeType.ALL)
     private List<ShoppingCartItem> booksInCart = new ArrayList<>();
-    @OneToOne
+
+    @ManyToOne // many shoppingCarts should be able to map to the same inventory
     private Inventory inventory;
     private Double totalPrice;
 
@@ -43,10 +41,10 @@ public class ShoppingCart {
      * @param inventory     the inventory from which the cart shops from
      * @author Maisha Abdullah
      */
-    public ShoppingCart(Inventory inventory, BookUser user){
+    public ShoppingCart(Inventory inventory, BookUser bookUser){
         this.inventory = inventory;
         this.totalPrice = 0.0;
-        this.user = user;
+//        this.bookUser = bookUser;
     }
 
     /**
@@ -224,24 +222,6 @@ public class ShoppingCart {
      */
     public Long getId() {
         return id;
-    }
-
-    /**
-     * Method to get the user of this shopping cart
-     * @return the user
-     * @author Maisha Abdullah
-     */
-    public BookUser getUser() {
-        return user;
-    }
-
-    /**
-     * Method to set the user of this shopping cart
-     * @param user the user
-     * @author Maisha Abdullah
-     */
-    public void setUser(BookUser user) {
-        this.user = user;
     }
 
     /**

--- a/src/main/java/bookstore/inventory/ShoppingCart.java
+++ b/src/main/java/bookstore/inventory/ShoppingCart.java
@@ -5,7 +5,6 @@
 
 package bookstore.inventory;
 
-import bookstore.users.BookUser;
 import jakarta.persistence.*;
 
 
@@ -34,17 +33,6 @@ public class ShoppingCart {
     public ShoppingCart(Inventory inventory){
         this.inventory = inventory;
         this.totalPrice = 0.0;
-    }
-
-    /**
-     * Constructor for ShoppingCart
-     * @param inventory     the inventory from which the cart shops from
-     * @author Maisha Abdullah
-     */
-    public ShoppingCart(Inventory inventory, BookUser bookUser){
-        this.inventory = inventory;
-        this.totalPrice = 0.0;
-//        this.bookUser = bookUser;
     }
 
     /**

--- a/src/main/java/bookstore/users/BookOwner.java
+++ b/src/main/java/bookstore/users/BookOwner.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Controller;
  * @author Thanuja Sivaananthan
  */
 @Entity
-@Controller
 public class BookOwner extends BookUser {
 
     /**

--- a/src/main/java/bookstore/users/BookUser.java
+++ b/src/main/java/bookstore/users/BookUser.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Controller;
  * @author Thanuja Sivaananthan
  */
 @Entity
-@Controller
 public class BookUser {
 
     @Id

--- a/src/main/java/bookstore/users/BookUser.java
+++ b/src/main/java/bookstore/users/BookUser.java
@@ -21,7 +21,7 @@ public class BookUser {
 
     public UserType userType;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToOne
     private ShoppingCart shoppingCart;
 
     /**

--- a/src/main/java/bookstore/users/BookUser.java
+++ b/src/main/java/bookstore/users/BookUser.java
@@ -1,10 +1,7 @@
 package bookstore.users;
 
 import bookstore.inventory.ShoppingCart;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.*;
 import org.springframework.stereotype.Controller;
 
 /**
@@ -24,7 +21,7 @@ public class BookUser {
 
     public UserType userType;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private ShoppingCart shoppingCart;
 
     /**

--- a/src/main/java/bookstore/users/UserController.java
+++ b/src/main/java/bookstore/users/UserController.java
@@ -20,7 +20,8 @@ public class UserController {
 
     @Autowired
     private final UserRepository userRepository;
-    private final UserRepository loggedInUserRepository;
+    private final UsersessionRepository usersessionRepository;
+
 
     private final ShoppingCartRepository shoppingCartRepository;
     private boolean userAccess = false;
@@ -32,10 +33,10 @@ public class UserController {
      * @param userRepository user repository
      * @author Thanuja Sivaananthan
      */
-    public UserController(UserRepository userRepository, UserRepository loggedInUserRepository, ShoppingCartRepository shoppingCartRepository) {
+    public UserController(UserRepository userRepository, ShoppingCartRepository shoppingCartRepository, UsersessionRepository usersessionRepository) {
         this.userRepository = userRepository;
         this.shoppingCartRepository = shoppingCartRepository;
-        this.loggedInUserRepository = loggedInUserRepository;
+        this.usersessionRepository = usersessionRepository;
     }
 
     /**
@@ -125,8 +126,21 @@ public class UserController {
      */
     @GetMapping("/login")
     public String accountForm(Model model) {
-        model.addAttribute("user", new BookUser());
-        return "login"; // one form for both account creation and login
+
+        // go directly to the existing usersession - TODO display message saying already logged in?
+        // otherwise, allow the user to login
+
+        BookUser existingUser = getLoggedInUser();
+        if (existingUser == null) {
+            model.addAttribute("user", new BookUser());
+            return "login"; // one form for both account creation and login
+        } else {
+            System.out.println("automatically logging into user: " + existingUser.getUsername());
+
+            this.userAccess = true;
+            model.addAttribute("user", existingUser);
+            return "redirect:/listAvailableBooks"; // Redirect to user profile page
+        }
     }
 
     /**
@@ -152,8 +166,11 @@ public class UserController {
                 if (existingUser.getPassword().equals(formUser.getPassword())) {
                     // Passwords match, login successful
                     model.addAttribute("user", existingUser);
-                    loggedInUserRepository.deleteAll(); // TODO - remove the current user in the log out
-                    loggedInUserRepository.save(existingUser);
+                    if (usersessionRepository.findByBookUser(existingUser) == null){
+                        usersessionRepository.save(new Usersession(existingUser));
+                    } else {
+                        System.out.println("ERROR, usersession already exists for user:" + existingUser);
+                    }
                     this.userAccess = true;
                     return "redirect:/listAvailableBooks"; // Redirect to user profile page
                 } else {
@@ -171,6 +188,20 @@ public class UserController {
         }
     }
 
+    public BookUser getLoggedInUser(){
+
+        List<Usersession> usersessions = (List<Usersession>) usersessionRepository.findAll();
+
+        BookUser loggedInUser = null;
+
+        if (!usersessions.isEmpty()){
+            loggedInUser = usersessions.get(usersessions.size()-1).getBookUser();
+        }
+
+        return loggedInUser;
+    }
+
+
     /**
      * Post mapping for logout request
      * @return register-login page
@@ -179,6 +210,11 @@ public class UserController {
     @PostMapping("/logout")
     public String handleUserLogout() {
         this.userAccess = false;
+
+        BookUser bookUser = getLoggedInUser();
+        System.out.println("logging out of user: " + bookUser.getUsername());
+        usersessionRepository.delete(usersessionRepository.findByBookUser(bookUser));
+
         return "redirect:/";
     }
 

--- a/src/main/java/bookstore/users/UserController.java
+++ b/src/main/java/bookstore/users/UserController.java
@@ -79,13 +79,11 @@ public class UserController {
             bookUser = new BookOwner(bookUser.getId(), bookUser.getUsername(), bookUser.getPassword(), bookUser.getShoppingCart());
         }
 
+        // need to save shoppingCarts first, then set shoppingCart for the user, then save the user
         ShoppingCart shoppingCart = new ShoppingCart(inventoryRepository.findById(1));
-        userRepository.save(bookUser);
         shoppingCartRepository.save(shoppingCart);
         bookUser.setShoppingCart(shoppingCart);
-        shoppingCart.setUser(bookUser);
-//        userRepository.save(bookUser);
-//        shoppingCartRepository.save(shoppingCart);
+        userRepository.save(bookUser);
 
         return bookUser;
     }

--- a/src/main/java/bookstore/users/UserController.java
+++ b/src/main/java/bookstore/users/UserController.java
@@ -1,5 +1,6 @@
 package bookstore.users;
 
+import bookstore.inventory.InventoryRepository;
 import bookstore.inventory.ShoppingCart;
 import bookstore.inventory.ShoppingCartRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +25,8 @@ public class UserController {
 
 
     private final ShoppingCartRepository shoppingCartRepository;
+    private final InventoryRepository inventoryRepository;
+
     private boolean userAccess = false;
 
 
@@ -33,9 +36,10 @@ public class UserController {
      * @param userRepository user repository
      * @author Thanuja Sivaananthan
      */
-    public UserController(UserRepository userRepository, ShoppingCartRepository shoppingCartRepository, UsersessionRepository usersessionRepository) {
+    public UserController(UserRepository userRepository, ShoppingCartRepository shoppingCartRepository, InventoryRepository inventoryRepo, UsersessionRepository usersessionRepository) {
         this.userRepository = userRepository;
         this.shoppingCartRepository = shoppingCartRepository;
+        this.inventoryRepository = inventoryRepo;
         this.usersessionRepository = usersessionRepository;
     }
 
@@ -57,11 +61,8 @@ public class UserController {
     @GetMapping("/register")
     public String createAccountForm(Model model) {
         BookUser bookUser = new BookUser();
-        ShoppingCart shoppingCart= new ShoppingCart();
-        bookUser.setShoppingCart(shoppingCart);
-        shoppingCart.setUser(bookUser);
 
-        model.addAttribute("shoppingCart", shoppingCart);
+
         model.addAttribute("user", bookUser);
         return "register";
     }
@@ -77,7 +78,15 @@ public class UserController {
             // setup as owner if specified
             bookUser = new BookOwner(bookUser.getId(), bookUser.getUsername(), bookUser.getPassword(), bookUser.getShoppingCart());
         }
+
+        ShoppingCart shoppingCart = new ShoppingCart(inventoryRepository.findById(1));
         userRepository.save(bookUser);
+        shoppingCartRepository.save(shoppingCart);
+        bookUser.setShoppingCart(shoppingCart);
+        shoppingCart.setUser(bookUser);
+//        userRepository.save(bookUser);
+//        shoppingCartRepository.save(shoppingCart);
+
         return bookUser;
     }
 

--- a/src/main/java/bookstore/users/Usersession.java
+++ b/src/main/java/bookstore/users/Usersession.java
@@ -1,0 +1,59 @@
+package bookstore.users;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+
+
+/**
+ * Usersession
+ *
+ * @author Thanuja Sivaananthan
+ */
+@Entity
+public class Usersession {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @OneToOne
+    private BookUser bookUser;
+
+    public Usersession(BookUser bookUser){
+        this.bookUser = bookUser;
+    }
+
+    public Usersession(){
+        this(null);
+    }
+
+
+    /**
+     * Get id
+     * @author Thanuja Sivaananthan
+     * @return  id
+     */
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * Set id
+     * @author Thanuja Sivaananthan
+     * @param id      id to set
+     */
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+
+    public BookUser getBookUser() {
+        return bookUser;
+    }
+
+    public void setBookUser(BookUser bookUser) {
+        this.bookUser = bookUser;
+    }
+}

--- a/src/main/java/bookstore/users/UsersessionRepository.java
+++ b/src/main/java/bookstore/users/UsersessionRepository.java
@@ -1,0 +1,17 @@
+package bookstore.users;
+
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+
+/**
+ * Usersession Repository
+ *
+ * @author Thanuja Sivaananthan
+ */
+public interface UsersessionRepository extends CrudRepository<Usersession, Long> {
+
+    Usersession findByBookUser(BookUser bookUser);
+
+    Usersession findById(long id);
+}

--- a/src/test/java/bookstore/inventory/CheckoutControllerTest.java
+++ b/src/test/java/bookstore/inventory/CheckoutControllerTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import bookstore.users.BookUser;
+import bookstore.users.UsersessionRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,6 +44,9 @@ class CheckoutControllerTest {
 
     @Mock
     private ShoppingCartItemRepository shoppingCartItemRepository;
+
+    @Mock
+    private UsersessionRepository usersessionRepository;
 
     private Book book1;
     private Book book2;
@@ -91,7 +96,9 @@ class CheckoutControllerTest {
      */
     @Test
     void testConfirmOrder() {
-        when(shoppingCartRepository.findById(1)).thenReturn(shoppingCart);
+        BookUser bookUser = new BookUser("testUser", "password123");
+        bookUser.setShoppingCart(shoppingCart);
+        when(userController.getLoggedInUser()).thenReturn(bookUser);
 
         Model model = new ConcurrentModel();
 
@@ -127,7 +134,7 @@ class CheckoutControllerTest {
 
         Assertions.assertEquals("access-denied", view);
         Assertions.assertEquals(shoppingCart.getBooksInCart(), model.getAttribute("items"));
-        Assertions.assertTrue(model.containsAttribute("totalPrice"));
+        Assertions.assertFalse(model.containsAttribute("totalPrice"));
 
     }
     

--- a/src/test/java/bookstore/users/UserControllerOwnerTest.java
+++ b/src/test/java/bookstore/users/UserControllerOwnerTest.java
@@ -1,5 +1,6 @@
 package bookstore.users;
 
+import bookstore.inventory.ShoppingCart;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -10,6 +11,7 @@ import org.springframework.ui.ConcurrentModel;
 import org.springframework.ui.Model;
 
 import java.util.Collections;
+import java.util.Objects;
 
 /**
  * UserController Owner Specific Tests
@@ -24,6 +26,9 @@ public class UserControllerOwnerTest {
 
     @MockBean
     private UserRepository userRepository;
+
+    @MockBean
+    private UsersessionRepository usersessionRepository;
 
     /**
      * Test adding a new owner is successful
@@ -42,6 +47,7 @@ public class UserControllerOwnerTest {
         Assertions.assertEquals(user1.getUsername(), modelUser.getUsername());
         Assertions.assertEquals(user1.getPassword(), modelUser.getPassword());
         Assertions.assertEquals(UserType.BOOKOWNER, modelUser.getUserType());
+        Assertions.assertNotNull(modelUser.getShoppingCart());
     }
 
     /**
@@ -62,6 +68,7 @@ public class UserControllerOwnerTest {
         Assertions.assertEquals(user1.getUsername(), modelUser.getUsername());
         Assertions.assertEquals(user1.getPassword(), modelUser.getPassword());
         Assertions.assertEquals(UserType.BOOKOWNER, modelUser.getUserType());
+        Assertions.assertNotNull(modelUser.getShoppingCart());
     }
 
     // add Owner login tests
@@ -74,11 +81,14 @@ public class UserControllerOwnerTest {
     void successfulLogin() {
         // Mocking userRepository
         BookUser existingOwner = new BookOwner("ExistingOwner", "password123");
+        existingOwner.setShoppingCart(new ShoppingCart());
+
         Mockito.when(userRepository.findByUsername("ExistingOwner")).thenReturn(Collections.singletonList(existingOwner));
 
         Model model = new ConcurrentModel();
         String result = controller.handleUserLogin(existingOwner, model);
         Assertions.assertEquals("redirect:/listAvailableBooks", result);
         Assertions.assertEquals(existingOwner, model.getAttribute("user"));
+        Assertions.assertNotNull(((BookUser) Objects.requireNonNull(model.getAttribute("user"))).getShoppingCart());
     }
 }

--- a/src/test/java/bookstore/users/UserControllerTest.java
+++ b/src/test/java/bookstore/users/UserControllerTest.java
@@ -3,6 +3,7 @@ package bookstore.users;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 
+import bookstore.inventory.ShoppingCart;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -13,6 +14,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.ui.ConcurrentModel;
 import org.springframework.ui.Model;
 import java.util.Collections;
+import java.util.Objects;
 
 
 /**
@@ -28,6 +30,9 @@ class UserControllerTest {
 
     @MockBean
     private UserRepository userRepository;
+
+    @MockBean
+    private UsersessionRepository usersessionRepository;
 
     @Test
     void contextLoads() {
@@ -45,6 +50,7 @@ class UserControllerTest {
         String result = controller.createAccountSubmit(user1, model);
         Assertions.assertEquals("redirect:/login", result);
         Assertions.assertEquals(user1, model.getAttribute("user"));
+        Assertions.assertNotNull(((BookUser) Objects.requireNonNull(model.getAttribute("user"))).getShoppingCart());
     }
 
     /**
@@ -116,12 +122,14 @@ class UserControllerTest {
     void successfulLogin() {
         // Mocking userRepository
         BookUser existingUser = new BookUser("ExistingUser", "password123");
+        existingUser.setShoppingCart(new ShoppingCart());
         Mockito.when(userRepository.findByUsername("ExistingUser")).thenReturn(Collections.singletonList(existingUser));
 
         Model model = new ConcurrentModel();
         String result = controller.handleUserLogin(existingUser, model);
         Assertions.assertEquals("redirect:/listAvailableBooks", result);
         Assertions.assertEquals(existingUser, model.getAttribute("user"));
+        Assertions.assertNotNull(((BookUser) Objects.requireNonNull(model.getAttribute("user"))).getShoppingCart());
     }
 
     /**
@@ -236,7 +244,9 @@ class UserControllerTest {
     @Test
     void loginWithMultipleUsers() {
         BookUser user1 = new BookUser("User1", "password1");
+        user1.setShoppingCart(new ShoppingCart());
         BookUser user2 = new BookUser("User2", "password2");
+        user2.setShoppingCart(new ShoppingCart());
 
         Mockito.when(userRepository.findByUsername("User1")).thenReturn(Collections.singletonList(user1));
         Mockito.when(userRepository.findByUsername("User2")).thenReturn(Collections.singletonList(user2));
@@ -245,11 +255,13 @@ class UserControllerTest {
         String result = controller.handleUserLogin(user1, model);
         Assertions.assertEquals("redirect:/listAvailableBooks", result);
         Assertions.assertEquals(user1, model.getAttribute("user"));
+        Assertions.assertNotNull(((BookUser) Objects.requireNonNull(model.getAttribute("user"))).getShoppingCart());
 
         model = new ConcurrentModel();
         result = controller.handleUserLogin(user2, model);
         Assertions.assertEquals("redirect:/listAvailableBooks", result);
         Assertions.assertEquals(user2, model.getAttribute("user"));
+        Assertions.assertNotNull(((BookUser) Objects.requireNonNull(model.getAttribute("user"))).getShoppingCart());
     }
 
 


### PR DESCRIPTION
Changes:
- check `userAccess` at the beginning of the method, and add the `access-denied` messages for other endpoints
- removed `ShoppingCart`'s `user` attribute. This wasn't being used, and seemed to complicate saving in the repository.
- fix to connect `user` and `shoppingcart`, rather than creating a new shoppingcart each time
   - this means a user can login, add books, logout, and re-login to get the existing cart 
- implemented an initial `usersession` that saves in the database
    - the previous `loggedInUserRepository` caused issues with deleting all the created users (creating user1 and user2, then logging in/out of user1 ends up deleting user2 completely). This PR fixes that issue at least.
    - this allows user1 to login/logout, then user2 to login/logout, and for user1 to login/logout again later.
    - Note, this is NOT a final solution. Ideally we should use `cookies`, so that each browser can have independent sessions at the same time. This will be addressed with https://github.com/waheebh1/online-bookstore/issues/43